### PR TITLE
fix: Ensure special chars don't cause iissues in temporary tgz files

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,7 @@ function buildLibrary(name, dir) {
 
 function packAndInstallLibrary(name, dir, targetDir) {
   const libDestDir = targetDir + "/node_modules/" + name
-  const tmpName = `${name}${Date.now()}.tgz`
+  const tmpName = `${name}${Date.now()}.tgz`.replace(/[\s\/]/g, '-',);
   try {
     console.log("[relative-deps] Copying to local node_modules")
     child_process.execSync(`yarn pack --filename ${tmpName}`, {


### PR DESCRIPTION
Fixes folder name problem raised in issue #9