### PR TITLE
Rollup lots of minor issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,10 @@ const rimraf = require("rimraf")
 const globby = require("globby")
 const checksum = require("checksum")
 
+// Under Windows, we must invoke yarn.cmd if we use execFile* and
+// we need to use execFile* to deal with spaces in args that are file names.
+const yarnCmd = process.platform === "win32" ? "yarn.cmd" : "yarn"
+
 async function main() {
   const projectPkgJson = readPkgUp.sync()
 
@@ -29,18 +33,14 @@ async function main() {
       (projectPkgJson.package.devDependencies && projectPkgJson.package.devDependencies[name])
 
     if (!regularDep) {
-      console.warn(
-        `[relative-deps][WARN] The relative dependency '${name}' should also be added as normal- or dev-dependency`
-      )
+      console.warn(`[relative-deps][WARN] The relative dependency '${name}' should also be added as normal- or dev-dependency`)
     }
 
     // Check if target dir exists
     if (!fs.existsSync(libDir)) {
       // Nope, but is the dependency mentioned as normal dependency in the package.json? Use that one
       if (regularDep) {
-        console.warn(
-          `[relative-deps][WARN] Could not find target directory '${libDir}', using normally installed version ('${regularDep}') instead`
-        )
+        console.warn(`[relative-deps][WARN] Could not find target directory '${libDir}', using normally installed version ('${regularDep}') instead`)
         return
       } else {
         console.error(
@@ -65,12 +65,12 @@ async function main() {
 }
 
 async function libraryHasChanged(name, libDir, targetDir, hashStore) {
-  const hashFile = targetDir + "/node_modules/" + name + "/.relative-deps-hash"
+  const hashFile = path.join(targetDir, "node_modules", name, ".relative-deps-hash")
   const referenceContents = fs.existsSync(hashFile) ? fs.readFileSync(hashFile, "utf8") : ""
   // compute the hahses
   const libFiles = await findFiles(libDir, targetDir)
   const hashes = []
-  for (file of libFiles) hashes.push(await getFileHash(libDir + "/" + file))
+  for (file of libFiles) hashes.push(await getFileHash(path.join(libDir, file)))
   const contents = libFiles.map((file, index) => hashes[index] + " " + file).join("\n")
   hashStore.file = hashFile
   hashStore.hash = contents
@@ -108,23 +108,24 @@ async function findFiles(libDir, targetDir) {
 }
 
 function buildLibrary(name, dir) {
-  console.log("[relative-deps] Building " + name)
   // Run install if never done before
-  if (!fs.existsSync(dir + "/node_modules")) {
-    child_process.execSync("yarn install", {
+  if (!fs.existsSync(path.join(dir, "node_modules"))) {
+    console.log(`[relative-deps] Running 'yarn install' in ${dir}`)
+    child_process.execFileSync(yarnCmd, ["install"], {
       cwd: dir,
       stdio: [0, 1, 2]
     })
   }
 
   // Run build script if present
-  const libraryPkgJson = JSON.parse(fs.readFileSync(dir + "/package.json", "utf8"))
+  const libraryPkgJson = JSON.parse(fs.readFileSync(path.join(dir, "package.json"), "utf8"))
   if (!libraryPkgJson.name === name) {
     console.error(`[relative-deps][ERROR] Mismatch in package name: found '${libraryPkgJson.name}', expected '${name}'`)
     process.exit(1)
   }
   if (libraryPkgJson.scripts && libraryPkgJson.scripts.build) {
-    child_process.execSync("yarn build", {
+    console.log(`[relative-deps] Building ${name} in ${dir}`)
+    child_process.execFileSync(yarnCmd, ["build"], {
       cwd: dir,
       stdio: [0, 1, 2]
     })
@@ -132,11 +133,13 @@ function buildLibrary(name, dir) {
 }
 
 function packAndInstallLibrary(name, dir, targetDir) {
-  const libDestDir = targetDir + "/node_modules/" + name
-  const tmpName = `${name}${Date.now()}.tgz`.replace(/[\s\/]/g, '-',);
+  const libDestDir = path.join(targetDir, "node_modules", name)
+  // Need to replace white space, slashes and at-signs in name
+  const tmpName = `${name}${Date.now()}.tgz`.replace(/[\s\/]/g, "-").replace(/@/g, "at-")
+  const fullTmpName = path.join(dir, tmpName)
   try {
     console.log("[relative-deps] Copying to local node_modules")
-    child_process.execSync(`yarn pack --filename ${tmpName}`, {
+    child_process.execFileSync(yarnCmd, ["pack", "--filename", tmpName], {
       cwd: dir,
       stdio: [0, 1, 2]
     })
@@ -147,11 +150,16 @@ function packAndInstallLibrary(name, dir, targetDir) {
     }
     fs.mkdirSync(libDestDir)
 
-    child_process.execSync(`tar zxf ${dir}/${tmpName} --strip-components=1 -C ${libDestDir} package`, {
-      stdio: [0, 1, 2]
-    })
+    console.log(`[relative-deps] Extracting "${fullTmpName}" to ${libDestDir}`)
+    child_process.execFileSync(
+      "tar",
+      ["zxf", path.relative(process.cwd(), fullTmpName), "--strip-components=1", "-C", path.relative(process.cwd(), libDestDir), "package"],
+      {
+        stdio: [0, 1, 2]
+      }
+    )
   } finally {
-    fs.unlinkSync(dir + "/" + tmpName)
+    fs.unlinkSync(fullTmpName)
   }
 }
 
@@ -164,4 +172,4 @@ async function getFileHash(file) {
   })
 }
 
-main()
+main().catch(e => console.error(e))


### PR DESCRIPTION
This includes changes from #11 and #12 along with lots of minor things.  For example, it uses `execFile*` instead of `exec*` which addresses issues with spaces in file names on Windows.  BUT, by using `execFile*`, we need to use `yarn.cmd` on Windows when running `yarn`, so it handles that.  Also, at least when I use the `tar` that comes with `git`/`bash` on Windows, it can handle `\\` in file names, but it doesn't like the `C:\\` at the start.  So I changed the `tar` command to use relative path names.

These are all the issues I could find so far that were causing me grief on Windows so this addresses all the issues I raised in #8.

Oh, it also handles scoped packages (*i.e.,* when formulating the tar file name, it replaces the `@`).