### PR TITLE
call 'npm run build' instead of invalid 'npm build'

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ function buildLibrary(name, dir) {
   }
   if (libraryPkgJson.scripts && libraryPkgJson.scripts.build) {
     console.log(`[relative-deps] Building ${name} in ${dir}`)
-    spawn.sync(["build"], { cwd: dir, stdio: [0, 1, 2] })
+    spawn.sync(["run", "build"], { cwd: dir, stdio: [0, 1, 2] })
   }
 }
 


### PR DESCRIPTION
We're using `relative-deps` in an npm application. It was working fine until v1.0.1 – as long as we made sure that yarn was globally installed. But starting with v1.0.2, it now tries and fails to build the relative dependency via npm: `'npm build' called with no arguments`.

To my understanding, `yarn run build`, `yarn build`, and `npm run build` are valid while `npm build` is not; so I'd say `run build` should work in both cases.

Thanks for sharing this library btw, it works great for us! 👍