### PR TITLE
fix passing arguments to cross-spawn

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,7 +209,7 @@ function installRelativeDepsPackage() {
     (pkg.dependencies && pkg.dependencies["relative-deps"])
   )) {
     console.log('[relative-deps] Installing relative-deps package')
-    spawn.sync(["add -D relative-deps"])
+    spawn.sync(["add", "-D", "relative-deps"])
   }
 }
 
@@ -263,7 +263,7 @@ async function addRelativeDeps({ paths, dev, script }) {
   libraries.forEach(library => {
     if (!pkg[depsKey][library.name]) {
       try {
-        spawn.sync([`add ${dev ? "-D" : ""} ${library.name}`], { stdio: "ignore" })
+        spawn.sync(["add", ...[dev ? ["-D"] : []], library.name], { stdio: "ignore" })
       } catch (_e) {
         console.log(`[relative-deps][WARN] Unable to fetch ${library.name} from registry. Installing as a relative dependency only.`)
       }


### PR DESCRIPTION
Closes https://github.com/mweststrate/relative-deps/issues/35 This issue was related to the way of passing arguments to the `cross-spawn`. I reproduced the issue with `mobx-state-tree` and checked fix with one of the examples there, worked fine for me. Also fixed in other place where it may cause some further issues. I also turned on notifications for repo, issue might have been fixed earlier if I had notifications on:)