### PR TITLE
Add .relative-deps-ignore option, to solve double rebuild in TS / other compiled or built repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ You can run `relative-deps watch` and it'll run `relative-deps` command when one
 This can go along with config of your project to watch over the relevant packages and it will automate the process completely,
 allowing you to change a library code and to enjoy the befefit of hot-reload.
 
+### 🔔 If you get multiple re-builds (due to your project being compiled, and then "new changes" found again): for the relative-dep, in it's folder, add a `.relative-deps-ignore` file with `!dist` or similar entries
+```
+!dist
+!.output
+!.built
+```
+
 # How
 
 Roughly, it works like this (obviously this can get out of date quickly):

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ async function libraryHasChanged(name, libDir, targetDir, hashStore) {
   const hashFile = path.join(targetDir, "node_modules", name, ".relative-deps-hash")
   const referenceContents = fs.existsSync(hashFile) ? fs.readFileSync(hashFile, "utf8") : ""
   // glob pattern list, relative to libDir, made for adding "dist" and similar
-  relativeDepsIgnoreFile = path.join(libDir, ".relative-deps-ignore")
+  const relativeDepsIgnoreFile = path.join(libDir, ".relative-deps-ignore")
   const additionalIgnoredList = fs.existsSync(relativeDepsIgnoreFile)
     ? fs.readFileSync(relativeDepsIgnoreFile, "utf8")
       .split("\n")


### PR DESCRIPTION
This resolves #55 - Watch mode **rebuilds multiple times**.

The cause was that **`dist`** directory was not ignored for change detection. 

This PR adds not just "static" `dist` directory ignore, but a flexible option of adding **`.relative-deps-ignore`** file into the Lib directory, to then specify `!dist` for example. 

- Works with multiple lines to specify multiple ignored dirs (`!build, !.output`) 
- Supports comments in `.relative-deps-ignore` (anything after `#` on any given line is ignored/skipped) 
- Readme updated to describe this option.

Please review & should be safe to merge! @mweststrate 